### PR TITLE
セルの種類を追加

### DIFF
--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -22,7 +22,7 @@ export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({
           <Button
             key={type}
             variant={selectedCellType === type ? 'default' : 'outline'}
-            className={`w-full ${CELL_TYPES[type].color} ${type === 'white' ? 'text-black' : 'text-white'} truncate`} // 文字の省略を防止
+            className={`w-full ${CELL_TYPES[type].color} ${type === 'white' || type === 'empty' ? 'text-black' : 'text-white'} truncate`} // 文字の省略を防止
             onClick={() => onCellTypeChange(type)}
           >
             {CELL_TYPES[type].label}

--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -13,16 +13,16 @@ export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({
   onCellTypeChange 
 }) => {
   return (
-    <Card className="w-64">
+    <Card className="w-full max-w-32 mx-auto">
       <CardHeader>
         <CardTitle>セル種類</CardTitle>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-2">
+      <CardContent className="flex flex-col gap-2">
         {(Object.keys(CELL_TYPES) as CellType[]).map((type) => (
           <Button
             key={type}
             variant={selectedCellType === type ? 'default' : 'outline'}
-            className={`${CELL_TYPES[type].color} text-white`}
+            className={`w-full ${CELL_TYPES[type].color} ${type === 'white' ? 'text-black' : 'text-white'} truncate`} // 文字の省略を防止
             onClick={() => onCellTypeChange(type)}
           >
             {CELL_TYPES[type].label}

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -103,17 +103,17 @@ export const Grid: React.FC<GridProps> = ({
     });
   };
 
-  // グリッドビューのレンダリングを修正
   const renderGridCell = (cellType: CellType, rowIndex: number, colIndex: number) => {
-    console.log(cellType);
+    const isEmpty = cellType === 'empty';
     return (
       <div
         key={`${rowIndex}-${colIndex}`}
-        className={`h-10 w-10 border ${CELL_TYPES[cellType].color}`}
+        className={`h-10 w-10 ${isEmpty ? '' : 'border'} ${CELL_TYPES[cellType].color}`}
         onClick={() => handleGridCellClick(rowIndex, colIndex)}
       />
     );
   };
+  
 
   return (
     <Card className="flex-grow">

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -56,7 +56,6 @@ export const Grid: React.FC<GridProps> = ({
     });
   };
 
-  // グリッドセルのクリックハンドラを修正
   const handleGridCellClick = (rowIndex: number, colIndex: number) => {
     // 通常のセル選択モード
     if (!panelPlacementMode.panel) {
@@ -66,20 +65,16 @@ export const Grid: React.FC<GridProps> = ({
       setGridHistory(prev => [...prev, newGrid]);
       return;
     }
-
+  
     // パネル配置モード
     const placingPanel = panelPlacementMode.panel;
-    const panelRows = placingPanel.cells.length;
-    const panelCols = placingPanel.cells[0].length;
-
-    // パネルを配置できるかチェック
-    const canPlacePanel =
-      rowIndex + panelRows <= grid.length &&
-      colIndex + panelCols <= grid[0].length;
-
-    if (canPlacePanel) {
+  
+    if (canPlacePanelAtLocation(grid, rowIndex, colIndex, placingPanel)) {
       const updatedGrid = grid.map((row) => [...row]);
-
+  
+      const panelRows = placingPanel.cells.length;
+      const panelCols = placingPanel.cells[0].length;
+  
       for (let i = 0; i < panelRows; i++) {
         for (let j = 0; j < panelCols; j++) {
           if (placingPanel.cells[i][j] === 'black') {
@@ -88,20 +83,21 @@ export const Grid: React.FC<GridProps> = ({
           }
         }
       }
-
+  
       // 現在のグリッド状態を履歴に追加
       setGridHistory(prev => [...prev, updatedGrid]);
       setPanelPlacementHistory(prev => [...prev, panelPlacementMode]);
-
+  
       setGrid(updatedGrid);
     }
-
+  
     // パネル配置モードをリセット
     setPanelPlacementMode({
       panel: null,
       highlightedCell: null,
     });
   };
+  
 
   const renderGridCell = (cellType: CellType, rowIndex: number, colIndex: number) => {
     const isEmpty = cellType === 'empty';
@@ -113,6 +109,36 @@ export const Grid: React.FC<GridProps> = ({
       />
     );
   };
+
+  const canPlacePanelAtLocation = (
+    grid: CellType[][],
+    rowIndex: number,
+    colIndex: number,
+    panel: Panel
+  ): boolean => {
+    const panelRows = panel.cells.length;
+    const panelCols = panel.cells[0].length;
+  
+    // グリッド範囲内に収まるか
+    if (rowIndex + panelRows > grid.length || colIndex + panelCols > grid[0].length) {
+      return false;
+    }
+  
+    // パネルを配置するセルがすべて white または black であるかチェック
+    for (let i = 0; i < panelRows; i++) {
+      for (let j = 0; j < panelCols; j++) {
+        if (panel.cells[i][j] === 'black') {
+          const targetCell = grid[rowIndex + i][colIndex + j];
+          if (targetCell !== 'white' && targetCell !== 'black') {
+            return false;
+          }
+        }
+      }
+    }
+  
+    return true;
+  };
+  
   
 
   return (

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -1,4 +1,4 @@
-export type CellType = 'white' | 'black' | 'start' | 'goal' | 'obstacle';
+export type CellType =  'white' | 'black' | 'start' | 'goal' | 'dummy-goal' | 'crow';
 
 export interface Panel {
   id: string;

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -1,4 +1,4 @@
-export type CellType =  'white' | 'black' | 'start' | 'goal' | 'dummy-goal' | 'crow';
+export type CellType =  'empty' | 'white' | 'black' | 'start' | 'goal' | 'dummy-goal' | 'crow';
 
 export interface Panel {
   id: string;

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -1,6 +1,7 @@
 import { CellType, CellTypeConfig } from '../components/types';
 
 export const CELL_TYPES: Record<CellType, CellTypeConfig> = {
+  'empty': { label: '空', color: '', code: 'e' },
   'white': { label: '白', color: 'bg-white', code: 'w' },
   'black': { label: '黒', color: 'bg-black', code: 'b' },
   'start': { label: '開始', color: 'bg-green-500', code: 's' },

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -5,5 +5,6 @@ export const CELL_TYPES: Record<CellType, CellTypeConfig> = {
   'black': { label: '黒', color: 'bg-black', code: 'b' },
   'start': { label: '開始', color: 'bg-green-500', code: 's' },
   'goal': { label: 'ゴール', color: 'bg-blue-500', code: 'g' },
-  'obstacle': { label: '障害物', color: 'bg-red-500', code: 'o' },
+  'dummy-goal': { label: 'ダミーゴール', color: 'bg-red-500', code: 'd' },
+  'crow': { label: 'カラス', color: 'bg-yellow-500', code: 'c' },
 };


### PR DESCRIPTION
## issue
- #15 

Close #15 

## 作業内容
- CellTypeにempty, dummy-goal, crowを追加
- emptyは枠線を消す

その他
- パネルを置ける条件を絞る：white/blackがある場所にだけ置ける
- セル種類選択のレスポンシブデザイン化

## 動作確認方法
-

## 今後の課題
-
