### PR TITLE
#28 yaml形式の変更

### DIFF
--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { CellType } from '../types';
-import { CELL_TYPES } from '../../constants/cell-types';
+import { CellDefinitions } from '../types';
+import { CELL_DEFINITIONS } from '../../constants/cell-types';
 
 interface CellTypeSelectorProps {
-  selectedCellType: CellType;
-  onCellTypeChange: (type: CellType) => void;
+  selectedCellType: CellDefinitions;
+  onCellTypeChange: (type: CellDefinitions) => void;
 }
 
 export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({ 
@@ -18,14 +18,14 @@ export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({
         <CardTitle>セル種類</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
-        {(Object.keys(CELL_TYPES) as CellType[]).map((type) => (
+        {(Object.keys(CELL_DEFINITIONS) as CellDefinitions[]).map((type) => (
           <Button
             key={type}
             variant={selectedCellType === type ? 'default' : 'outline'}
-            className={`w-full ${CELL_TYPES[type].color} ${CELL_TYPES[type].color === "bg-white" ? 'text-black' : 'text-white'} truncate`} // 文字の省略を防止
+            className={`w-full ${CELL_DEFINITIONS[type].color} ${CELL_DEFINITIONS[type].color === "bg-white" ? 'text-black' : 'text-white'} truncate`} // 文字の省略を防止
             onClick={() => onCellTypeChange(type)}
           >
-            {CELL_TYPES[type].label}
+            {CELL_DEFINITIONS[type].label}
           </Button>
         ))}
       </CardContent>

--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -10,7 +10,7 @@ interface CellTypeSelectorProps {
 
 export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({ 
   selectedCellType, 
-  onCellTypeChange 
+  onCellTypeChange,
 }) => {
   return (
     <Card className="w-full max-w-32 mx-auto bg-[#B3B9D1]">
@@ -18,6 +18,7 @@ export const CellTypeSelector: React.FC<CellTypeSelectorProps> = ({
         <CardTitle>セル種類</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
+
         {(Object.keys(CELL_DEFINITIONS) as CellDefinitions[]).map((type) => (
           <Button
             key={type}

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle, } from '@/components/ui/card';
 // import { PlusCircle, MinusCircle, Download, Upload, Link } from 'lucide-react';
-import { PlusCircle, MinusCircle,  } from 'lucide-react';
+import { PlusCircle, MinusCircle, Link  } from 'lucide-react';
 import { GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType , CellDefinitions} from '../types';
 import { CELL_DEFINITIONS, CellSideInfo } from '../../constants/cell-types';
 // import { exportStageToYaml, importStageFromYaml } from '../../utils/yaml';
-// import { shareStageUrl } from '../../utils/url';
+import { shareStageUrl } from '../../utils/url';
 
 interface GridProps {
   grid: GridCell[][];
@@ -250,8 +250,8 @@ export const Grid: React.FC<GridProps> = ({
           </Button>
         </div>
 
-        {/* <div className="flex gap-2 mt-4">
-          <Button onClick={() => exportStageToYaml(grid, panels)} className="flex items-center gap-2">
+        <div className="flex gap-2 mt-4">
+          {/* <Button onClick={() => exportStageToYaml(grid, panels)} className="flex items-center gap-2">
             <Download size={16} /> YAMLエクスポート
           </Button>
           <input
@@ -265,11 +265,11 @@ export const Grid: React.FC<GridProps> = ({
             <Button onClick={triggerFileInput} variant="outline" className="flex items-center gap-2">
               <Upload size={16} /> YAMLインポート
             </Button>
-          </label>
+          </label> */}
           <Button onClick={() => shareStageUrl(grid, panels)} className="mt-4 flex items-center gap-2">
             <Link size={16} /> URLを生成
           </Button>
-        </div> */}
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -37,18 +37,31 @@ export const Grid: React.FC<GridProps> = ({
     setGrid((prevGrid) => {
       const newRows = prevGrid.length + rowDelta;
       const newCols = prevGrid[0].length + colDelta;
-
+  
       if (newRows > 0 && newCols > 0) {
+        // 新しい空のセルを作成するヘルパー関数
+        const createEmptyCell = (): GridCell => ({
+          type: 'Normal',
+          side: 'front'
+        });
+  
         if (rowDelta > 0) {
-          return [...prevGrid, ...Array(rowDelta).fill(Array(newCols).fill('White'))];
+          // 行を追加
+          const newRow = Array(newCols).fill(null).map(() => createEmptyCell());
+          return [...prevGrid, ...Array(rowDelta).fill(null).map(() => newRow.map(cell => ({...cell})))];
         } else if (rowDelta < 0) {
-          return prevGrid.slice(0, newRows).map((row) => row.slice(0, newCols));
+          // 行を削除
+          return prevGrid.slice(0, newRows).map(row => row.slice(0, newCols));
         }
-
-        return prevGrid.map((row) => {
+  
+        // 列の追加/削除
+        return prevGrid.map(row => {
           if (colDelta > 0) {
-            return [...row, ...Array(colDelta).fill('White')];
+            // 列を追加
+            const newCells = Array(colDelta).fill(null).map(() => createEmptyCell());
+            return [...row, ...newCells];
           } else if (colDelta < 0) {
+            // 列を削除
             return row.slice(0, newCols);
           }
           return row;

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -85,7 +85,7 @@ export const Grid: React.FC<GridProps> = ({
   
       for (let i = 0; i < panelRows; i++) {
         for (let j = 0; j < panelCols; j++) {
-          if (placingPanel.cells[i][j] !== 'Empty') {
+          if (placingPanel.cells[i][j] === 'Black') {
             const targetCell = updatedGrid[rowIndex + i][colIndex + j];
             
             // Emptyには置かない
@@ -170,11 +170,11 @@ export const Grid: React.FC<GridProps> = ({
             return false;
           }
   
-          // neutralなセルには置けない（開始、ゴール、ダミーゴールなど）
-          const cellDef = CELL_DEFINITIONS[targetCell.type];
-          if ('neutral' in cellDef) {
-            return false;
-          }
+          // // neutralなセルには置けない（開始、ゴール、ダミーゴールなど）
+          // const cellDef = CELL_DEFINITIONS[targetCell.type];
+          // if ('neutral' in cellDef) {
+          //   return false;
+          // }
         }
       }
     }

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -105,6 +105,8 @@ export const Grid: React.FC<GridProps> = ({
       setGridHistory((prev) => [...prev, updatedGrid]);
       setPanelPlacementHistory((prev) => [...prev, panelPlacementMode]);
       setGrid(updatedGrid);
+
+      console.log('updatedGrid', updatedGrid);
     }
   
     setPanelPlacementMode({
@@ -117,21 +119,14 @@ export const Grid: React.FC<GridProps> = ({
     const cellDef = CELL_DEFINITIONS[cell.type];
     
     // セルの状態に応じた情報を取得
-    let sideInfo: CellSideInfo | undefined;
-
-    if (cellDef.neutral) {
-      sideInfo = cellDef.neutral;
-    } else if (cellDef.front) {
-      sideInfo = cellDef.front;
-    } else if (cellDef.back) {
-      sideInfo = cellDef.back;
-    }
+    const sideInfo: CellSideInfo | undefined = cellDef[cell.side];
 
     if (!sideInfo) {
       console.error(`No valid sideInfo found for cell type: ${cell.type}`);
       return null; // またはデフォルトの要素を返す
     }
-    
+
+    console.log('レンダリング');
     return (
       <div
         key={`${rowIndex}-${colIndex}`}

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 // import { PlusCircle, MinusCircle, Download, Upload, Link } from 'lucide-react';
 import { PlusCircle, MinusCircle,  } from 'lucide-react';
-import { CellType, GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '../types';
+import { GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType , CellDefinitions} from '../types';
 import { CELL_DEFINITIONS, CellSideInfo } from '../../constants/cell-types';
 // import { exportStageToYaml, importStageFromYaml } from '../../utils/yaml';
 // import { shareStageUrl } from '../../utils/url';
@@ -11,7 +11,7 @@ interface GridProps {
   grid: GridCell[][];
   setGrid: React.Dispatch<React.SetStateAction<GridCell[][]>>;
   setGridHistory: React.Dispatch<React.SetStateAction<GridCell[][][]>>;
-  selectedCellType: CellType;
+  selectedCellType: CellDefinitions;
   panels: Panel[];
   setPanels: React.Dispatch<React.SetStateAction<Panel[]>>;
   panelPlacementMode: PanelPlacementModeType;

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, } from '@/components/ui/card';
-// import { PlusCircle, MinusCircle, Download, Upload, Link } from 'lucide-react';
-import { PlusCircle, MinusCircle, Link  } from 'lucide-react';
+import { PlusCircle, MinusCircle, Download, Upload, Link } from 'lucide-react';
 import { GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType , CellDefinitions} from '../types';
 import { CELL_DEFINITIONS, CellSideInfo } from '../../constants/cell-types';
-// import { exportStageToYaml, importStageFromYaml } from '../../utils/yaml';
+import { exportStageToYaml, importStageFromYaml } from '../../utils/yaml';
 import { shareStageUrl } from '../../utils/url';
 
 interface GridProps {
@@ -24,9 +23,7 @@ export const Grid: React.FC<GridProps> = ({
   setGrid,
   setGridHistory,
   selectedCellType,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   panels,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setPanels,
   panelPlacementMode,
   setPanelPlacementMode,
@@ -207,13 +204,12 @@ export const Grid: React.FC<GridProps> = ({
     return true;
   };
   
-  // const triggerFileInput = () => {
-  //   const input = document.getElementById('yamlImport') as HTMLInputElement;
-  //   if (input) {
-  //     input.click();
-  //   }
-  // };
-  
+  const triggerFileInput = () => {
+    const input = document.getElementById('yamlImport') as HTMLInputElement;
+    if (input) {
+      input.click();
+    }
+  };
 
   return (
     <Card className="flex-grow bg-[#B3B9D1]">
@@ -251,7 +247,7 @@ export const Grid: React.FC<GridProps> = ({
         </div>
 
         <div className="flex gap-2 mt-4">
-          {/* <Button onClick={() => exportStageToYaml(grid, panels)} className="flex items-center gap-2">
+          <Button onClick={() => exportStageToYaml(grid, panels)} className="flex items-center gap-2">
             <Download size={16} /> YAMLエクスポート
           </Button>
           <input
@@ -265,7 +261,7 @@ export const Grid: React.FC<GridProps> = ({
             <Button onClick={triggerFileInput} variant="outline" className="flex items-center gap-2">
               <Upload size={16} /> YAMLインポート
             </Button>
-          </label> */}
+          </label>
           <Button onClick={() => shareStageUrl(grid, panels)} className="mt-4 flex items-center gap-2">
             <Link size={16} /> URLを生成
           </Button>

--- a/frontend/src/components/editor/grid.tsx
+++ b/frontend/src/components/editor/grid.tsx
@@ -72,19 +72,34 @@ export const Grid: React.FC<GridProps> = ({
   };
 
   const handleGridCellClick = (rowIndex: number, colIndex: number) => {
-    // 通常のセル選択モード
+    // セル選択モード
     if (!panelPlacementMode.panel) {
       const newGrid = [...grid];
       
-      // デフォルトでfrontかneutralを選択
       const cellDef = CELL_DEFINITIONS[selectedCellType];
-      const side = 'neutral' in cellDef ? 'neutral' : 'front';
-      newGrid[rowIndex][colIndex] = { type: selectedCellType, side };
-  
+
+      // セル選択がFlipの場合：sideを反転
+      if (selectedCellType === 'Flip') {
+        const targetCell = newGrid[rowIndex][colIndex];
+        if (targetCell.type === 'Empty') return;
+
+        if (targetCell.side === 'front') {
+          newGrid[rowIndex][colIndex] = { ...targetCell, side: 'back' };
+        } else if (targetCell.side === 'back') {
+          newGrid[rowIndex][colIndex] = { ...targetCell, side: 'front' };
+        }
+      }
+
+      else {
+        // 基本はfront（表）で設置する。neutralのみの場合はneutral
+        const side = 'neutral' in cellDef ? 'neutral' : 'front';
+        newGrid[rowIndex][colIndex] = { type: selectedCellType, side };
+      }
+
       setGrid(newGrid);
       setGridHistory((prev) => [...prev, newGrid]);
-      
       return;
+      
     }
   
     // パネル配置モード
@@ -118,8 +133,6 @@ export const Grid: React.FC<GridProps> = ({
       setGridHistory((prev) => [...prev, updatedGrid]);
       setPanelPlacementHistory((prev) => [...prev, panelPlacementMode]);
       setGrid(updatedGrid);
-
-      console.log('updatedGrid', updatedGrid);
     }
   
     setPanelPlacementMode({
@@ -139,7 +152,6 @@ export const Grid: React.FC<GridProps> = ({
       return null; // またはデフォルトの要素を返す
     }
 
-    console.log('レンダリング');
     return (
       <div
         key={`${rowIndex}-${colIndex}`}

--- a/frontend/src/components/editor/panel-list.tsx
+++ b/frontend/src/components/editor/panel-list.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trash2, Move } from 'lucide-react';
-import { CellType, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '../types';
+import {  Panel, PanelPlacementModeType, PanelPlacementHistoryType, GridCell } from '../types';
 
 interface PanelListProps {
   panels: Panel[];
@@ -10,9 +10,9 @@ interface PanelListProps {
   setPanelPlacementMode: React.Dispatch<React.SetStateAction<PanelPlacementModeType>>;
   panelPlacementHistory: PanelPlacementHistoryType[];
   setPanelPlacementHistory: React.Dispatch<React.SetStateAction<PanelPlacementHistoryType[]>>;
-  setGrid: React.Dispatch<React.SetStateAction<CellType[][]>>;
-  gridHistory: CellType[][][];
-  setGridHistory: React.Dispatch<React.SetStateAction<CellType[][][]>>;
+  setGrid: React.Dispatch<React.SetStateAction<GridCell[][]>>;
+  gridHistory: GridCell[][][];
+  setGridHistory: React.Dispatch<React.SetStateAction<GridCell[][][]>>;
 }
 
 export const PanelList: React.FC<PanelListProps> = ({

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -1,10 +1,11 @@
-import { CELL_DEFINITIONS } from "../constants/cell-types";
+import { CELL_TYPES, CELL_DEFINITIONS } from "../constants/cell-types";
 
-;export type CellType = keyof typeof CELL_DEFINITIONS;
+export type CellType = keyof typeof CELL_TYPES
+export type CellDefinitions = keyof typeof CELL_DEFINITIONS;
 
 // グリッド上のセルを表す型
 export type GridCell = {
-  type: CellType;
+  type: CellDefinitions;
   side: 'neutral' | 'front' | 'back';
 };
 

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -1,18 +1,22 @@
-import { CELL_TYPES } from "../constants/cell-types";
+import { CELL_DEFINITIONS } from "../constants/cell-types";
 
-export type CellType = keyof typeof CELL_TYPES;
+;export type CellType = keyof typeof CELL_DEFINITIONS;
 
+// グリッド上のセルを表す型
+export type GridCell = {
+  type: CellType;
+  side: 'neutral' | 'front' | 'back';
+};
+
+// パネルの型を更新
 export interface Panel {
   id: string;
   cells: CellType[][];
 }
 
-export interface PanelPlacementModeType {
+export type PanelPlacementModeType = {
   panel: Panel | null;
   highlightedCell: { row: number; col: number } | null;
-}
+};
 
-export interface PanelPlacementHistoryType {
-  panel: Panel | null;
-  highlightedCell: { row: number; col: number } | null;
-}
+export type PanelPlacementHistoryType = PanelPlacementModeType;

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -25,6 +25,7 @@ export type CellSideInfo = {
 // セルの定義を表す型
 export type CellDefinition = {
   label: string;
+  color: string;
   neutral?: CellSideInfo;
   front?: CellSideInfo;
   back?: CellSideInfo;
@@ -34,6 +35,7 @@ export type CellDefinition = {
 export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
   Empty: {
     label: '空',
+    color: 'bg-white',
     neutral: {
       code: 'e',
       picture: 'empty.png'
@@ -41,6 +43,7 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
   },
   Normal: {
     label: '通常床',
+    color: 'bg-[#DAE0EA]',
     front: {
       code: 'N',
       picture: 'white.png'
@@ -52,6 +55,7 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
   },
   Start: {
     label: 'スタート',
+    color: 'bg-green-500',
     neutral: {
       code: 's',
       picture: 'start.png'
@@ -59,6 +63,7 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
   },
   Goal: {
     label: 'ゴール',
+    color: 'bg-blue-500',
     neutral: {
       code: 'g',
       picture: 'goal.png'
@@ -66,9 +71,12 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
   },
   DummyGoal: {
     label: 'ダミーゴール',
+    color: 'bg-red-500',
     neutral: {
       code: 'd',
       picture: 'dummyGoal.png'
     }
   }
 } as const;
+
+export type CellDefinitions = keyof typeof CELL_DEFINITIONS;

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -49,11 +49,11 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
     label: '通常床',
     color: 'bg-[#DAE0EA]',
     front: {
-      code: 'N',
+      code: 'w',
       picture: 'white.png'
     },
     back: {
-      code: 'n',
+      code: 'b',
       picture: 'black.png'
     }
   },
@@ -80,7 +80,19 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
       code: 'd',
       picture: 'dummy-goal.png'
     }
-  }
+  },
+  Crow: {
+    label: 'カラス',
+    color: 'bg-yellow-500',
+    front: {
+      code: 'c',
+      picture: 'crow.png'
+    },
+    back: {
+      code: 'C',
+      picture: 'black.png'
+    }
+  },
 } as const;
 
 export type CellDefinitions = keyof typeof CELL_DEFINITIONS;

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -74,7 +74,7 @@ export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
     color: 'bg-red-500',
     neutral: {
       code: 'd',
-      picture: 'dummyGoal.png'
+      picture: 'dummy-goal.png'
     }
   }
 } as const;

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -33,6 +33,10 @@ export type CellDefinition = {
 
 // セルの種類を定義
 export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
+  Flip: {
+    label: '反転',
+    color: 'bg-black',
+  },
   Empty: {
     label: '空',
     color: 'bg-white',

--- a/frontend/src/constants/cell-types.ts
+++ b/frontend/src/constants/cell-types.ts
@@ -14,3 +14,61 @@ export const CELL_TYPES = {
 
 // キーから動的に型を生成
 export type CellType = keyof typeof CELL_TYPES;
+// export type CellType = 'Empty' | 'White' | 'Black' | 'Start' | 'Goal' | 'DummyGoal' | 'Crow' | 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'Normal';
+
+// セルの状態を表す型
+export type CellSideInfo = {
+  code: string;
+  picture: string;
+};
+
+// セルの定義を表す型
+export type CellDefinition = {
+  label: string;
+  neutral?: CellSideInfo;
+  front?: CellSideInfo;
+  back?: CellSideInfo;
+};
+
+// セルの種類を定義
+export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
+  Empty: {
+    label: '空',
+    neutral: {
+      code: 'e',
+      picture: 'empty.png'
+    }
+  },
+  Normal: {
+    label: '通常床',
+    front: {
+      code: 'N',
+      picture: 'white.png'
+    },
+    back: {
+      code: 'n',
+      picture: 'black.png'
+    }
+  },
+  Start: {
+    label: 'スタート',
+    neutral: {
+      code: 's',
+      picture: 'start.png'
+    }
+  },
+  Goal: {
+    label: 'ゴール',
+    neutral: {
+      code: 'g',
+      picture: 'goal.png'
+    }
+  },
+  DummyGoal: {
+    label: 'ダミーゴール',
+    neutral: {
+      code: 'd',
+      picture: 'dummyGoal.png'
+    }
+  }
+} as const;

--- a/frontend/src/pages/editor-page.tsx
+++ b/frontend/src/pages/editor-page.tsx
@@ -3,15 +3,15 @@ import { CellTypeSelector } from '@/components/editor/cell-type-selector';
 import { Grid } from '@/components/editor/grid';
 import { PanelList } from '@/components/editor/panel-list';
 import { NewPanelCreator } from '@/components/editor/new-panel-creator';
-import { CellType, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '@/components/types';
-import { decodeStageFromUrl } from '../utils/url';
+import { CellType, GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '@/components/types';
+// import { decodeStageFromUrl } from '../utils/url';
 
 const EditorPage: React.FC = () => {
 
-  const [grid, setGrid] = useState<CellType[][]>([
-    ['White', 'White', 'White'],
-    ['White', 'White', 'White'],
-    ['White', 'White', 'White'],
+  const [grid, setGrid] = useState<GridCell[][]>([
+    [{ type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }],
+    [{ type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }],
+    [{ type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }],
   ]);
 
   const [selectedCellType, setSelectedCellType] = useState<CellType>('Black');
@@ -41,22 +41,22 @@ const EditorPage: React.FC = () => {
     highlightedCell: null,
   });
 
-  const [gridHistory, setGridHistory] = useState<CellType[][][]>([grid]);
+  const [gridHistory, setGridHistory] = useState<GridCell[][][]>([grid]);
   const [panelPlacementHistory, setPanelPlacementHistory] = useState<PanelPlacementHistoryType[]>([]);
 
-  useEffect(() => {
+  // useEffect(() => {
 
-    const params = new URLSearchParams(window.location.search);
-    const cells = params.get('cells');
-    const panels = params.get('panels');
+  //   const params = new URLSearchParams(window.location.search);
+  //   const cells = params.get('cells');
+  //   const panels = params.get('panels');
     
-    if (cells && panels) {
-      const stageData = `cells=${cells}&panels=${panels}`;
-      const parsedData = decodeStageFromUrl(stageData);
-      setGrid(parsedData.cells);
-      setPanels(parsedData.panels);
-    }
-  }, []);
+  //   if (cells && panels) {
+  //     const stageData = `cells=${cells}&panels=${panels}`;
+  //     const parsedData = decodeStageFromUrl(stageData);
+  //     setGrid(parsedData.cells);
+  //     setPanels(parsedData.panels);
+  //   }
+  // }, []);
 
   // FastAPIの疎通確認
   useEffect(() => {

--- a/frontend/src/pages/editor-page.tsx
+++ b/frontend/src/pages/editor-page.tsx
@@ -4,6 +4,7 @@ import { Grid } from '@/components/editor/grid';
 import { PanelList } from '@/components/editor/panel-list';
 import { NewPanelCreator } from '@/components/editor/new-panel-creator';
 import { CellType, GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '@/components/types';
+import { CellDefinitions } from 'constants/cell-types';
 // import { decodeStageFromUrl } from '../utils/url';
 
 const EditorPage: React.FC = () => {
@@ -14,7 +15,7 @@ const EditorPage: React.FC = () => {
     [{ type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }, { type: 'Normal', side: 'front' }],
   ]);
 
-  const [selectedCellType, setSelectedCellType] = useState<CellType>('Black');
+  const [selectedCellType, setSelectedCellType] = useState<CellDefinitions>('Black');
   const [panels, setPanels] = useState<Panel[]>([
     {
       id: 'panel1',

--- a/frontend/src/pages/editor-page.tsx
+++ b/frontend/src/pages/editor-page.tsx
@@ -5,7 +5,7 @@ import { PanelList } from '@/components/editor/panel-list';
 import { NewPanelCreator } from '@/components/editor/new-panel-creator';
 import { CellType, GridCell, Panel, PanelPlacementModeType, PanelPlacementHistoryType } from '@/components/types';
 import { CellDefinitions } from 'constants/cell-types';
-// import { decodeStageFromUrl } from '../utils/url';
+import { decodeStageFromUrl } from '../utils/url';
 
 const EditorPage: React.FC = () => {
 
@@ -45,19 +45,19 @@ const EditorPage: React.FC = () => {
   const [gridHistory, setGridHistory] = useState<GridCell[][][]>([grid]);
   const [panelPlacementHistory, setPanelPlacementHistory] = useState<PanelPlacementHistoryType[]>([]);
 
-  // useEffect(() => {
+  useEffect(() => {
 
-  //   const params = new URLSearchParams(window.location.search);
-  //   const cells = params.get('cells');
-  //   const panels = params.get('panels');
+    const params = new URLSearchParams(window.location.search);
+    const cells = params.get('cells');
+    const panels = params.get('panels');
     
-  //   if (cells && panels) {
-  //     const stageData = `cells=${cells}&panels=${panels}`;
-  //     const parsedData = decodeStageFromUrl(stageData);
-  //     setGrid(parsedData.cells);
-  //     setPanels(parsedData.panels);
-  //   }
-  // }, []);
+    if (cells && panels) {
+      const stageData = `cells=${cells}&panels=${panels}`;
+      const parsedData = decodeStageFromUrl(stageData);
+      setGrid(parsedData.cells);
+      setPanels(parsedData.panels);
+    }
+  }, []);
 
   // FastAPIの疎通確認
   useEffect(() => {

--- a/frontend/src/utils/string-operations.ts
+++ b/frontend/src/utils/string-operations.ts
@@ -1,0 +1,9 @@
+// 頭文字を大文字にする
+export const capitalize = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+// 頭文字を小文字にする
+export const uncapitalize = (str: string) => {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+};

--- a/frontend/src/utils/yaml.ts
+++ b/frontend/src/utils/yaml.ts
@@ -1,30 +1,32 @@
-import { CellType, Panel } from '@/components/types';
 import { parse, stringify } from 'yaml';
+import { CellDefinitions, CellType, Panel, GridCell } from '@/components/types';
+// import { CELL_DEFINITIONS, CELL_TYPES } from '../constants/cell-types';
+import { capitalize, uncapitalize } from './string-operations';
 
 interface CellYamlData {
   Type: {
     Type: string;
     SkinId: number;
   };
-  StartColor: string; // "Black", "White", "Empty"
+  CellSide: string;
 }
 
 interface PanelYamlData {
   Coordinates: { X: number; Y: number }[];
 }
 
-const transformCellToYamlFormat = (cell: CellType): CellYamlData => {
-  if (cell === 'Black' || cell === 'White') {
-    return { Type: { Type: 'Normal', SkinId: 0 }, StartColor: cell.charAt(0).toUpperCase() + cell.slice(1) };
-  }
-  if (cell === 'Empty') {
-    return { Type: { Type: 'Normal', SkinId: 0 }, StartColor: 'Empty' };
-  }
-  return { Type: { Type: cell || 'Normal', SkinId: 0 }, StartColor: 'White' };
+const transformCellToYamlFormat = (cell: GridCell): CellYamlData => {
+  return { 
+    Type: { 
+      Type: cell.type, 
+      SkinId: 0 
+    }, 
+    CellSide: capitalize(cell.side)
+  };
 };
 
 export const exportStageToYaml = (
-  grid: CellType[][],
+  grid: GridCell[][],
   panels: Panel[]
 ) => {
   const cells = grid.map(row => row.map(cell => transformCellToYamlFormat(cell)));
@@ -54,7 +56,7 @@ export const exportStageToYaml = (
 
 export const importStageFromYaml = (
   event: React.ChangeEvent<HTMLInputElement>,
-  setGrid: (grid: CellType[][]) => void,
+  setGrid: (grid: GridCell[][]) => void,
   setPanels: (panels: Panel[]) => void
 ) => {
   const file = event.target.files?.[0];
@@ -66,13 +68,11 @@ export const importStageFromYaml = (
         const { Height, Width, Cells, Panels } = yamlData;
 
         // グリッド変換
-        const grid: CellType[][] = Cells.map((row: CellYamlData[]) =>
-          row.map((cell: CellYamlData) => {
-            if (cell.Type.Type === 'Normal') {
-              return cell.StartColor as CellType;
-            }
-            return cell.Type.Type;
-          })
+        const grid: GridCell[][] = Cells.map((row: CellYamlData[]) =>
+          row.map((cell: CellYamlData) => ({
+            type: cell.Type.Type as CellDefinitions,
+            side: uncapitalize(cell.CellSide) as GridCell['side']
+          }))
         );
 
         // パネル変換とトリム


### PR DESCRIPTION
## issue
- 

Close 

## 

## 作業内容
### 型変更まわりの修正
- CELL_TYPESの型変更
- gridの型変更
- gridの描画処理変更
- 反転処理変更
- 反転ボタンを追加

### yamlとURL出力の修正
- yamlの形式変更
- URL共有の処理変更

### 詳細
「表裏」の概念が追加された。

以前はCELL_TYPESのみを使用していた。

```ts
export const CELL_TYPES = {
  Empty: { label: '空', color: 'bg-white', code: 'e', imagePath: '/cells/empty.png' },
  White: { label: '白', color: 'bg-white', code: 'w', imagePath: '/cells/white.png' },
  Black: { label: '黒', color: 'bg-black', code: 'b', imagePath: '/cells/black.png' },
  Start: { label: '開始', color: 'bg-green-500', code: 's', imagePath: '/cells/start.png' },
  Goal: { label: 'ゴール', color: 'bg-blue-500', code: 'g', imagePath: '/cells/goal.png' },
  DummyGoal: { label: 'ダミーゴール', color: 'bg-red-500', code: 'd', imagePath: '/cells/dummy-goal.png' },
  Crow: { label: 'カラス', color: 'bg-yellow-500', code: 'c', imagePath: '/cells/crow.png' },
  ArrowUp: { label: '矢印↑', color: 'bg-white', code: 'au', imagePath: '/cells/arrow-up.png' },
  ArrowDown: { label: '矢印↓', color: 'bg-white', code: 'ad', imagePath: '/cells/arrow-down.png' },
  ArrowLeft: { label: '矢印←', color: 'bg-white', code: 'al', imagePath: '/cells/arrow-left.png' },
  ArrowRight: { label: '矢印→', color: 'bg-white', code: 'ar', imagePath: '/cells/arrow-right.png' },
} as const;

// キーから動的に型を生成
export type CellType = keyof typeof CELL_TYPES;
```

これを、CELL_DEFINITIONSとGridCellの2つを使うことに。
CELL_DEFINITIONSはセルの定義（裏表ふくむ）、GridCellが現在の裏表の状態を格納する
```ts
// セルの状態を表す型
export type CellSideInfo = {
  code: string;
  picture: string;
};

// セルの定義を表す型
export type CellDefinition = {
  label: string;
  color: string;
  neutral?: CellSideInfo;
  front?: CellSideInfo;
  back?: CellSideInfo;
};

// セルの種類を定義
export const CELL_DEFINITIONS: Record<string, CellDefinition> = {
  Flip: {
    label: '反転',
    color: 'bg-black',
  },
  Empty: {
    label: '空',
    color: 'bg-white',
    neutral: {
      code: 'e',
      picture: 'empty.png'
    }
  },
  Normal: {
    label: '通常床',
    color: 'bg-[#DAE0EA]',
    front: {
      code: 'w',
      picture: 'white.png'
    },
    back: {
      code: 'b',
      picture: 'black.png'
    }
  },
  Start: {
    label: 'スタート',
    color: 'bg-green-500',
    neutral: {
      code: 's',
      picture: 'start.png'
    }
  },
  Goal: {
    label: 'ゴール',
    color: 'bg-blue-500',
    neutral: {
      code: 'g',
      picture: 'goal.png'
    }
  },
  DummyGoal: {
    label: 'ダミーゴール',
    color: 'bg-red-500',
    neutral: {
      code: 'd',
      picture: 'dummy-goal.png'
    }
  },
  Crow: {
    label: 'カラス',
    color: 'bg-yellow-500',
    front: {
      code: 'c',
      picture: 'crow.png'
    },
    back: {
      code: 'C',
      picture: 'black.png'
    }
  },
} as const;
```

および

```ts
// グリッド上のセルを表す型
export type GridCell = {
  type: CellDefinitions;
  side: 'neutral' | 'front' | 'back';
};
```

そのためGridに関する大部分が修正となった。
Panelに関しては一旦は修正を入れていないため、既存の型（CELL_TYPES）がそのまま残っている。

## 動作確認方法
-

## 今後の課題
-
