### PR TITLE
#56 editorモードのundoreset操作を復旧

### DIFF
--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { gridSlice } from '../store/slices/grid-slice';
 import { panelListSlice } from '../store/slices/panel-list-slice';
+import { studioModeInEditorSlice } from "../store/slices/studio-mode-in-editor-slice";
+import { RootState } from '../store';
+import { StudioModeInEditor } from "./types";
 
 import { CellTypeSelector } from '@/components/editor/cell-type-selector';
 import { Grid } from '@/components/editor/grid';
@@ -11,6 +14,10 @@ import { NewPanelCreator } from '@/components/editor/new-panel-creator';
 
 const EditorPage: React.FC = () => {
   const dispatch = useDispatch();
+  // Editor内スタジオモードを監視
+  const studioModeInEditor = useSelector(
+    (state: RootState) => state.studioModeInEditor.studioModeInEditor
+  );
 
   // Play->Editor移行時に、Playモード時のパネル配置をリセット
   useEffect(() => {
@@ -19,7 +26,20 @@ const EditorPage: React.FC = () => {
     
     // 最後に履歴を完全クリア
     dispatch(gridSlice.actions.clearHistory());
+
+    // 「Editor内スタジオモード」をEditorに変更
+    dispatch(studioModeInEditorSlice.actions.switchMode(StudioModeInEditor.Editor));
   }, [dispatch]);
+
+  // 「Editor内スタジオモード」を監視して、Editorに変わった時、履歴をクリア
+  useEffect(() => {
+    if (studioModeInEditor === StudioModeInEditor.Editor) {
+      // グリッド状態を元に戻すことなく、履歴クリアする
+      dispatch(gridSlice.actions.clearHistory());
+      // パネル配置はリセット
+      dispatch(panelListSlice.actions.reset());
+    }
+  }, [studioModeInEditor, dispatch]);
 
   return (
     <div className="flex flex-col gap-4 md:flex-row justify-start">

--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { gridSlice } from '../store/slices/grid-slice';
 import { panelListSlice } from '../store/slices/panel-list-slice';
+import { panelPlacementSlice } from '../store/slices/panel-placement-slice';
 import { studioModeInEditorSlice } from "../store/slices/studio-mode-in-editor-slice";
 import { RootState } from '../store';
 import { StudioModeInEditor } from "./types";
@@ -36,8 +37,9 @@ const EditorPage: React.FC = () => {
     if (studioModeInEditor === StudioModeInEditor.Editor) {
       // グリッド状態を元に戻すことなく、履歴クリアする
       dispatch(gridSlice.actions.clearHistory());
-      // パネル配置はリセット
+      // パネル配置リセット
       dispatch(panelListSlice.actions.reset());
+      dispatch(panelPlacementSlice.actions.clearPanelSelection());
     }
   }, [studioModeInEditor, dispatch]);
 

--- a/frontend/src/components/editor-page.tsx
+++ b/frontend/src/components/editor-page.tsx
@@ -12,11 +12,13 @@ import { NewPanelCreator } from '@/components/editor/new-panel-creator';
 const EditorPage: React.FC = () => {
   const dispatch = useDispatch();
 
-  // エディタモード時に、プレイモードで実施したパネル配置をリセット
+  // Play->Editor移行時に、Playモード時のパネル配置をリセット
   useEffect(() => {
     dispatch(gridSlice.actions.reset());
     dispatch(panelListSlice.actions.reset());
-
+    
+    // 最後に履歴を完全クリア
+    dispatch(gridSlice.actions.clearHistory());
   }, [dispatch]);
 
   return (

--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CellDefinitions, StudioModeInEditor } from "../types";
 import { CELL_DEFINITIONS } from "../../constants/cell-types";
-import { changeCellType } from "../../store/slices/cell-type-slice";
+import { cellTypeSlice } from "../../store/slices/cell-type-slice";
 import { studioModeInEditorSlice } from "../../store/slices/studio-mode-in-editor-slice";
 import { RootState } from "../../store";
 
@@ -17,7 +17,7 @@ export const CellTypeSelector: React.FC = () => {
   // セルをクリック -> 「Editor内スタジオモード」をEditorに変更し、セルタイプを変更
   const handleCellTypeChange = (cellType: CellDefinitions) => {
     dispatch(studioModeInEditorSlice.actions.switchMode(StudioModeInEditor.Editor));
-    dispatch(changeCellType(cellType));
+    dispatch(cellTypeSlice.actions.changeCellType(cellType));
   };
 
   return (

--- a/frontend/src/components/editor/cell-type-selector.tsx
+++ b/frontend/src/components/editor/cell-type-selector.tsx
@@ -2,9 +2,10 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CellDefinitions } from "../types";
+import { CellDefinitions, StudioModeInEditor } from "../types";
 import { CELL_DEFINITIONS } from "../../constants/cell-types";
 import { changeCellType } from "../../store/slices/cell-type-slice";
+import { studioModeInEditorSlice } from "../../store/slices/studio-mode-in-editor-slice";
 import { RootState } from "../../store";
 
 export const CellTypeSelector: React.FC = () => {
@@ -12,6 +13,12 @@ export const CellTypeSelector: React.FC = () => {
   const selectedCellType = useSelector(
     (state: RootState) => state.cellType.selectedCellType
   );
+
+  // セルをクリック -> 「Editor内スタジオモード」をEditorに変更し、セルタイプを変更
+  const handleCellTypeChange = (cellType: CellDefinitions) => {
+    dispatch(studioModeInEditorSlice.actions.switchMode(StudioModeInEditor.Editor));
+    dispatch(changeCellType(cellType));
+  };
 
   return (
     <Card className="w-full min-w-[120px] max-w-[300px] bg-[#B3B9D1]">
@@ -29,7 +36,7 @@ export const CellTypeSelector: React.FC = () => {
                 ? "text-black"
                 : "text-white"
             } truncate`}
-            onClick={() => dispatch(changeCellType(type))}
+            onClick={() => handleCellTypeChange(type)}
           >
             {CELL_DEFINITIONS[type].label}
           </Button>

--- a/frontend/src/components/editor/panel-list.tsx
+++ b/frontend/src/components/editor/panel-list.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Trash2, Move } from "lucide-react";
-import { Panel, StudioMode } from "../types";
+import { Panel, StudioMode, StudioModeInEditor } from "../types";
 import { panelListSlice } from "../../store/slices/panel-list-slice";
 import { panelPlacementSlice } from "../../store/slices/panel-placement-slice";
+import { studioModeInEditorSlice } from "../../store/slices/studio-mode-in-editor-slice";
 import { RootState } from "../../store";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -43,6 +44,11 @@ export const PanelList: React.FC = () => {
         highlightedCell: firstBlackCell || { row: 0, col: 0 },
       })
     );
+
+    // Editorの場合、「Editor内スタジオモード」をPlayに変更
+    if (studioMode === StudioMode.Editor) {
+      dispatch(studioModeInEditorSlice.actions.switchMode(StudioModeInEditor.Play));
+    }
   };
 
   // パネルビューのレンダリングを修正

--- a/frontend/src/components/editor/panel-list.tsx
+++ b/frontend/src/components/editor/panel-list.tsx
@@ -105,12 +105,7 @@ export const PanelList: React.FC = () => {
         <CardTitle>パネル</CardTitle>
       </CardHeader>
       <CardContent>
-
-        {/* Playモードの場合、プレイ専用パーツを追加 */}
-        {studioMode === StudioMode.Play && (
-          <PlacementControllPart />
-        )}
-        
+        <PlacementControllPart />
         {renderPanels()}
       </CardContent>
     </Card>

--- a/frontend/src/components/play-page.tsx
+++ b/frontend/src/components/play-page.tsx
@@ -2,13 +2,20 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { gridSlice } from '../store/slices/grid-slice';
+import { panelListSlice } from '../store/slices/panel-list-slice';
+
 import { Grid } from '@/components/editor/grid';
 import { PanelList } from '@/components/editor/panel-list';
 
+// Editor->Play移行時に、Playモード時のパネル配置をリセット
 const PlayPage: React.FC = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    dispatch(gridSlice.actions.reset());
+    dispatch(panelListSlice.actions.reset());
+
+    // 最後に履歴を完全クリア
     dispatch(gridSlice.actions.clearHistory());
   }, [dispatch]);
 

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -50,6 +50,16 @@ export interface StudioModeState {
   studioMode: StudioMode;
 }
 
+export enum StudioModeInEditor {
+  Editor = 'editor',
+  Play = 'play'
+}
+export interface StudioModeStateInEditor {
+  studioModeInEditor: StudioModeInEditor;
+}
+
+
+
 export interface GridState {
   grid: GridCell[][];
   gridHistory: GridCell[][][];

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import logger from 'redux-logger';
 
 import studioModeReducer from './slices/studio-mode-slice';
+import studioModeInEditorReducer from './slices/studio-mode-in-editor-slice';
 import cellTypeReducer from './slices/cell-type-slice';
 import panelListReducer from './slices/panel-list-slice';
 import panelPlacementReducer from './slices/panel-placement-slice';
@@ -12,6 +13,7 @@ import gridReducer from './slices/grid-slice';
 export const store = configureStore({
   reducer: {
     studioMode: studioModeReducer,
+    studioModeInEditor: studioModeInEditorReducer,
     cellType: cellTypeReducer,
     panelList: panelListReducer,
     panelPlacement: panelPlacementReducer,

--- a/frontend/src/store/slices/cell-type-slice.ts
+++ b/frontend/src/store/slices/cell-type-slice.ts
@@ -16,5 +16,4 @@ export const cellTypeSlice = createSlice({
   },
 });
 
-export const { changeCellType } = cellTypeSlice.actions;
 export default cellTypeSlice.reducer;

--- a/frontend/src/store/slices/create-panel-slice.ts
+++ b/frontend/src/store/slices/create-panel-slice.ts
@@ -48,5 +48,4 @@ export const createPanelSlice = createSlice({
   },
 });
 
-// export const { selectPanelForPlacement } = panelSlice.actions;
 export default createPanelSlice.reducer;

--- a/frontend/src/store/slices/grid-slice.ts
+++ b/frontend/src/store/slices/grid-slice.ts
@@ -72,36 +72,28 @@ export const gridSlice = createSlice({
         state.grid[row][col].side = state.grid[row][col].side === 'front' ? 'back' : 'front';
     },
 
-    // 履歴
-    clearHistory: (state) => {
-        state.gridHistory = [];
-    },
-
     saveHistory: (state) => {
         state.gridHistory.push(state.grid.map((row) => row.map((cell) => ({ ...cell }))));
     },
 
+    // undo, resetは最初の履歴は消さずに持っておく
     undo: (state) => {
         if (state.gridHistory.length >= 1) {
             state.grid = state.gridHistory[state.gridHistory.length - 1];
             state.gridHistory.pop();
-            
-            console.log(JSON.parse(JSON.stringify(state.gridHistory)));
-            console.log(JSON.parse(JSON.stringify(state.grid)));
         }
     },
 
     reset: (state) => {
         if (state.gridHistory.length >= 1) {
-            console.log(JSON.parse(JSON.stringify(state.gridHistory)));
-            console.log(JSON.parse(JSON.stringify(state.grid)));
-
             state.grid = state.gridHistory[0];
             state.gridHistory = [];
-
-            console.log(JSON.parse(JSON.stringify(state.gridHistory)));
-            console.log(JSON.parse(JSON.stringify(state.grid)));
         }
+    },
+
+    // clearは最初の履歴ふくめて完全に削除する
+    clearHistory: (state) => {
+        state.gridHistory = [];
     },
   },
 });

--- a/frontend/src/store/slices/grid-slice.ts
+++ b/frontend/src/store/slices/grid-slice.ts
@@ -98,5 +98,4 @@ export const gridSlice = createSlice({
   },
 });
 
-// export const { initGrid,  } = panelSlice.actions;
 export default gridSlice.reducer;

--- a/frontend/src/store/slices/panel-list-slice.ts
+++ b/frontend/src/store/slices/panel-list-slice.ts
@@ -74,5 +74,4 @@ export const panelListSlice = createSlice({
   },
 });
 
-// export const { selectPanelForPlacement } = panelSlice.actions;
 export default panelListSlice.reducer;

--- a/frontend/src/store/slices/panel-placement-slice.ts
+++ b/frontend/src/store/slices/panel-placement-slice.ts
@@ -34,5 +34,4 @@ export const panelPlacementSlice = createSlice({
   },
 });
 
-// export const { selectPanelForPlacement } = panelSlice.actions;
 export default panelPlacementSlice.reducer;

--- a/frontend/src/store/slices/studio-mode-in-editor-slice.ts
+++ b/frontend/src/store/slices/studio-mode-in-editor-slice.ts
@@ -1,0 +1,20 @@
+// studio-mode-slice.ts
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { StudioModeInEditor, StudioModeStateInEditor } from '../../components/types';
+
+const initialState: StudioModeStateInEditor = {
+  studioModeInEditor: StudioModeInEditor.Editor,
+};
+
+export const studioModeInEditorSlice = createSlice({
+  name: 'studioModeInEditor',
+  initialState,
+  reducers: {
+    switchMode(state, action: PayloadAction<StudioModeInEditor>) {
+      state.studioModeInEditor = action.payload;
+    },
+  },
+});
+
+// reducer 部分はデフォルトエクスポートとしてエクスポートしてもよい
+export default studioModeInEditorSlice.reducer;

--- a/frontend/src/store/slices/studio-mode-in-editor-slice.ts
+++ b/frontend/src/store/slices/studio-mode-in-editor-slice.ts
@@ -16,5 +16,4 @@ export const studioModeInEditorSlice = createSlice({
   },
 });
 
-// reducer 部分はデフォルトエクスポートとしてエクスポートしてもよい
 export default studioModeInEditorSlice.reducer;

--- a/frontend/src/store/slices/studio-mode-slice.ts
+++ b/frontend/src/store/slices/studio-mode-slice.ts
@@ -16,5 +16,4 @@ export const studioModeSlice = createSlice({
   },
 });
 
-// reducer 部分はデフォルトエクスポートとしてエクスポートしてもよい
 export default studioModeSlice.reducer;


### PR DESCRIPTION
## issue
- #56 

Close #56

## 作業内容
- Editorモードでも、Undo, Resetボタンを用意する
- Editor <-> Play の切り替え時にReset
- 「Editorモード内のStudioMode」を別途用意
  -  初期状態 -> Editor
  -  セル選択 -> Editor 
  -  パネル設置 -> Play
- Play -> Editorになった時に「履歴クリア＆使ったパネルを復活」
  - ただしボードの状態はそのまま


## 動作確認方法

開発環境にて、以下を確認：

- Editorで問題なくUndo, Resetが使えること
- Editor <-> Playの切り替えで齟齬が起きないこと
- Play -> Editorになった時に「履歴クリア＆使ったパネルが復活」されること

## 今後の課題
-
