### PR TITLE
#112 Yaml出力時に余分なEmpty削除

### DIFF
--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -24,9 +24,50 @@ const transformCellToYamlFormat = (cell: GridCell): CellYamlData => {
   };
 };
 
+// Empty削除関数：外側の余分なEmptyセルを削除
+const removeExtraEmptyCells = (grid: Grid): Grid => {
+  if (grid.length === 0 || grid[0].length === 0) return grid;
+  
+  let minRow = 0;
+  let maxRow = grid.length - 1;
+  let minCol = 0;
+  let maxCol = grid[0].length - 1;
+  
+  // 上から削除可能な行を見つける
+  while (minRow <= maxRow && grid[minRow].every(cell => cell.type === "Empty")) {
+    minRow++;
+  }
+  
+  // 下から削除可能な行を見つける
+  while (maxRow >= minRow && grid[maxRow].every(cell => cell.type === "Empty")) {
+    maxRow--;
+  }
+  
+  // 左から削除可能な列を見つける
+  while (minCol <= maxCol && grid.slice(minRow, maxRow + 1).every(row => row[minCol].type === "Empty")) {
+    minCol++;
+  }
+  
+  // 右から削除可能な列を見つける
+  while (maxCol >= minCol && grid.slice(minRow, maxRow + 1).every(row => row[maxCol].type === "Empty")) {
+    maxCol--;
+  }
+  
+  // すべてがEmptyの場合は1x1のEmptyグリッドを返す
+  if (minRow > maxRow || minCol > maxCol) {
+    return [[{ type: "Empty", side: "neutral" }]];
+  }
+  
+  // トリムされたグリッドを作成
+  return grid.slice(minRow, maxRow + 1).map(row => row.slice(minCol, maxCol + 1));
+};
+
 export const exportStageToYaml = (grid: Grid, panels: Panel[]) => {
+  // Empty削除処理を適用
+  const trimmedGrid = removeExtraEmptyCells(grid);
+  
   // Y軸を反転してYAMLに出力（上下逆さま）
-  const cells = [...grid].reverse().map((row) =>
+  const cells = [...trimmedGrid].reverse().map((row) =>
     row.map((cell) => transformCellToYamlFormat(cell))
   );
 
@@ -53,8 +94,8 @@ export const exportStageToYaml = (grid: Grid, panels: Panel[]) => {
   });
 
   const yamlStageData = {
-    Height: grid.length,
-    Width: grid[0].length,
+    Height: trimmedGrid.length,
+    Width: trimmedGrid[0].length,
     Cells: cells,
     Panels: panelCoordinates,
   };


### PR DESCRIPTION
## issue
- #112

Close #112

## 作業内容
- Yaml Export時に「余分なEmpty」を削除
  -   「余分なEmpty」 = 「一番外側の列または行すべてがEmptyだった場合の列または行」
    - 「一番外側の列または行」は、行・2列以上なこともありうる。外側であれば消す必要がある


## 動作確認方法
- 想定通りにYaml出力されることを確認

## 今後の課題
-
