### PR TITLE
✨ fix: yaml出力時に、panelsもy座標反転させる

### DIFF
--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -83,7 +83,7 @@ export const exportStageToYaml = (grid: Grid, panels: Panel[]) => {
         Coordinates: panel.cells
           .flatMap((row, y) =>
             row
-              .map((cell, x) => (cell === "Black" || cell === "Cut") ? { X: x, Y: y } : null)
+              .map((cell, x) => (cell === "Black" || cell === "Cut") ? { X: x, Y: panel.cells.length - 1 - y } : null)
               .filter((coord) => coord !== null)
           )
           .flat()
@@ -148,12 +148,13 @@ export const importStageFromYaml = async (
               );
               panel.Coordinates?.forEach(({ X, Y }) => {
                 // パネルタイプに応じてセルタイプを決定
+                const reversedY = Height - 1 - Y;
                 switch (panel.Type) {
                   case "Cut":
-                    panelGrid[Y][X] = "Cut";
+                    panelGrid[reversedY][X] = "Cut";
                     break;
                   default:
-                    panelGrid[Y][X] = "Black";
+                    panelGrid[reversedY][X] = "Black";
                 }
               });
               return {


### PR DESCRIPTION
## issue
- 

Close 

## 作業内容
- 前回Yaml出力に、cellsのみのy座標反転するよう実装したが、panelsも反転させる必要があったため、あべこべにさせてしまった
- panelsへの対応も追加

## 動作確認方法
- yaml.ts修正前と修正後でエクスポートしたyamlをUnityで利用し、パネルがy座標反転していることを確認

## 今後の課題
-
