### PR TITLE
✅ feat: #115 旗のyaml export調整、url読込時の不具合修正

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -126,7 +126,7 @@ export const decodeStageFromUrl = (stageData: string) => {
   const panels = panelsRaw.split("_").map((panelRaw, index) => {
     // プレフィックスからタイプ判定
     let panelStr = panelRaw;
-    let type: Panel["type"];
+    let type: Panel["type"] = "Normal"; // デフォルト値を設定
     if (panelStr.startsWith("c-")) {
       type = "Cut";
       panelStr = panelStr.slice(2);
@@ -147,6 +147,11 @@ export const decodeStageFromUrl = (stageData: string) => {
     const panelCells = Array.from({ length: height }, (_, i) =>
       decodedPanelCells.slice(i * width, (i + 1) * width)
     );
+
+    // Flagセルが含まれている場合はFlagタイプに設定
+    if (decodedPanelCells.includes("Flag")) {
+      type = "Flag";
+    }
 
     return { id: `panel-${index}`, cells: panelCells, type };
   });

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -76,21 +76,25 @@ export const exportStageToYaml = (grid: Grid, panels: Panel[]) => {
       Type: panel.type || "Normal"
     };
     
-    // Flagパネル以外の場合のみCoordinatesを追加
-    if (panel.type !== "Flag") {
+    // Flagパネルの場合は固定座標（X: 0, Y: 0）を追加
+    if (panel.type === "Flag") {
       return {
         ...baseData,
-        Coordinates: panel.cells
-          .flatMap((row, y) =>
-            row
-              .map((cell, x) => (cell === "Black" || cell === "Cut") ? { X: x, Y: panel.cells.length - 1 - y } : null)
-              .filter((coord) => coord !== null)
-          )
-          .flat()
+        Coordinates: [{ X: 0, Y: 0 }]
       };
     }
     
-    return baseData;
+    // Flag以外のパネルは通常の座標処理
+    return {
+      ...baseData,
+      Coordinates: panel.cells
+        .flatMap((row, y) =>
+          row
+            .map((cell, x) => (cell === "Black" || cell === "Cut") ? { X: x, Y: panel.cells.length - 1 - y } : null)
+            .filter((coord) => coord !== null)
+        )
+        .flat()
+    };
   });
 
   const yamlStageData = {


### PR DESCRIPTION
## issue
- #115

Close #115

## 作業内容
- 旗のYaml Exportの定義を調整
  - Coordinatesで必ずX: 0, Y: 0の1セルを出力させるようにした 
- URLステージ読込時にYaml ExportするとFlagがおかしくなっていたので修正した

## 動作確認方法
- エディタからのステージ作成、およびURLステージ読込からYaml Exportして、問題がなくYaml Exportできること

## 今後の課題
-
