### PR TITLE
#86 オオカミの対応

### DIFF
--- a/src/components/editor/panel-list/placement-controll-part.tsx
+++ b/src/components/editor/panel-list/placement-controll-part.tsx
@@ -7,7 +7,7 @@ import { RootState } from "@/store";
 import { useDispatch, useSelector } from "react-redux";
 import { useState } from "react";
 
-import { findPath } from "@/logic";
+import { evaluateAllPaths } from "@/logic";
 import { Result, resultMessages } from "@/types/path";
 import { StudioModeInEditor } from "@/types/store";
 
@@ -74,16 +74,20 @@ export const PlacementControllPart: React.FC = () => {
       // StudioModeInEditorをPlayに切り替え
       dispatch(studioModeInEditorSlice.actions.switchMode(StudioModeInEditor.Play));
 
-      const _pathResult = findPath(grid, phaseHistory);
+      const { startResult, wolfResults, finalResult } = evaluateAllPaths(grid, phaseHistory);
+      const _pathResult = startResult; // UI処理用にstartResultを使用
+      console.log(wolfResults);
 
       // 対応するResultMessageをポップアップ
-      if (_pathResult.result === Result.HasClearPath)
-          toast.success(resultMessages[_pathResult.result]) ;
+      if (finalResult === Result.WolfReachedGoal)
+          toast.error(resultMessages[finalResult]);
+      else if (_pathResult.result === Result.HasClearPath)
+          toast.success(resultMessages[_pathResult.result]);
       else
-          toast.info(resultMessages[_pathResult.result]) ;
+          toast.info(resultMessages[_pathResult.result]);
       
-      // クリアした場合は再生ボタンをdisable
-      if (_pathResult.result === Result.HasClearPath) {
+      // クリアした場合またはWolf失敗の場合は再生ボタンをdisable
+      if (_pathResult.result === Result.HasClearPath || finalResult === Result.WolfReachedGoal) {
           setIsCleared(true);
       }
       

--- a/src/logic/index.ts
+++ b/src/logic/index.ts
@@ -1,5 +1,6 @@
 // ロジック関数のエクスポート
 export { findPath, bfsAllShortestPaths, createRestTransitionGrid } from './pathfinding';
+export { evaluateAllPaths } from './pathfinding/wolf-evaluation';
 export { placePanels } from './panels';
 export { solveSingle, solveAll, solvePuzzle } from './solver';
 export type { SolveResponse } from './solver';

--- a/src/logic/pathfinding/wolf-evaluation.ts
+++ b/src/logic/pathfinding/wolf-evaluation.ts
@@ -1,0 +1,46 @@
+import { Grid } from '@/types/grid';
+import { PathResult, Result } from '@/types/path';
+import { findPath } from './main';
+import { findWolfPath } from './wolf';
+import { findAll } from '../utils';
+
+/**
+ * Wolf対応の統合判定関数
+ */
+export const evaluateAllPaths = (grid: Grid, phaseHistory?: Grid[]): {
+  startResult: PathResult;
+  wolfResults: PathResult[];
+  finalResult: Result;
+} => {
+  // 1. Startの経路取得
+  const startResult = findPath(grid, phaseHistory);
+  
+  // 2. 全Wolfの経路取得
+  const wolves = findAll(grid, 'Wolf');
+  const wolfResults: PathResult[] = [];
+  
+  for (let i = 0; i < wolves.length; i++) {
+    const wolfResult = findWolfPath(grid, wolves[i]);
+    wolfResults.push(wolfResult);
+  }
+  
+  // 3. 最終結果判定
+  const finalResult = determineFinalResult(startResult, wolfResults);
+  
+  return { startResult, wolfResults, finalResult };
+};
+
+/**
+ * 最終結果判定ロジック
+ */
+const determineFinalResult = (startResult: PathResult, wolfResults: PathResult[]): Result => {
+  // Wolfが本物ゴールに到達した場合は失敗
+  for (const wolfResult of wolfResults) {
+    if (wolfResult.result === Result.HasClearPath) {
+      return Result.WolfReachedGoal;
+    }
+  }
+  
+  // 全Wolfが阻まれ、Startの結果を返す
+  return startResult.result;
+};

--- a/src/logic/pathfinding/wolf/candidate-ranking.ts
+++ b/src/logic/pathfinding/wolf/candidate-ranking.ts
@@ -1,0 +1,16 @@
+import { Candidate } from '../types';
+
+/**
+ * オオカミ用の候補ソート処理
+ * 優先度: 経路長（短い順） → ゴール種類（本物ゴール優先）
+ */
+export const rankWolfCandidates = (candidates: Candidate[]): Candidate[] => {
+  return candidates.sort((a, b) => {
+    // 第一優先: 経路長（短い順）
+    if (a.path.length !== b.path.length) {
+      return a.path.length - b.path.length;
+    }
+    // 第二優先: 種類（本物ゴール優先: kind 0 < kind 1）
+    return a.kind - b.kind;
+  });
+};

--- a/src/logic/pathfinding/wolf/index.ts
+++ b/src/logic/pathfinding/wolf/index.ts
@@ -1,0 +1,1 @@
+export { findWolfPath } from './main';

--- a/src/logic/pathfinding/wolf/main.ts
+++ b/src/logic/pathfinding/wolf/main.ts
@@ -1,0 +1,74 @@
+import { Grid } from '@/types/grid';
+import { PathResult, Result } from '@/types/path';
+import { findSingle, findAll, Point } from '../../utils';
+import { bfsAllShortestPaths } from '../bfs';
+import { Candidate } from '../types';
+import { rankWolfCandidates } from './candidate-ranking';
+import { determineWolfResult } from './result-determination';
+
+/**
+ * オオカミ用の全ての目標地点（Goal/DummyGoal）への経路を収集
+ */
+const findWolfPaths = (grid: Grid, wolfStart: Point): {
+  realPaths: Point[][];
+  dummyPaths: Point[][];
+} => {
+  const goalReal = findSingle(grid, 'Goal');
+  const dummyGoals = findAll(grid, 'DummyGoal');
+  
+  // 最短経路群を取得
+  const realPaths = goalReal ? bfsAllShortestPaths(grid, wolfStart, goalReal) : [];
+  
+  // すべてのDummyGoalに対して最短経路を取得
+  const dummyPaths: Point[][] = [];
+  for (const dummyGoal of dummyGoals) {
+    dummyPaths.push(...bfsAllShortestPaths(grid, wolfStart, dummyGoal));
+  }
+  
+  return { realPaths, dummyPaths };
+};
+
+/**
+ * オオカミ用の経路候補リストを作成
+ */
+const createWolfCandidates = (
+  realPaths: Point[][],
+  dummyPaths: Point[][]
+): Candidate[] => {
+  const allCandidates: Candidate[] = [];
+  
+  for (const path of realPaths) {
+    allCandidates.push({ path, kind: 0, crowCount: 0 });
+  }
+  for (const path of dummyPaths) {
+    allCandidates.push({ path, kind: 1, crowCount: 0 });
+  }
+  
+  return allCandidates;
+};
+
+/**
+ * オオカミ経路探索メイン関数
+ * 優先度: 最短経路 → 本物ゴール優先
+ */
+export const findWolfPath = (grid: Grid, wolfPosition: Point): PathResult => {
+  // 1. 基本要素の検証
+  const goalReal = findSingle(grid, 'Goal');
+  if (!goalReal)
+    return { result: Result.NoGoal, path: [], nextGrid: null};
+
+  // 2. 全経路の収集
+  const { realPaths, dummyPaths } = findWolfPaths(grid, wolfPosition);
+  
+  // 3. 候補リストの作成
+  const allCandidates = createWolfCandidates(realPaths, dummyPaths);
+  if (allCandidates.length === 0)
+    return { result: Result.NoPath, path: [], nextGrid: null };
+  
+  // 4. 候補のソート
+  const sortedCandidates = rankWolfCandidates(allCandidates);
+  
+  // 5. 最終結果の判定
+  const best = sortedCandidates[0];
+  return determineWolfResult(best, grid, wolfPosition);
+};

--- a/src/logic/pathfinding/wolf/result-determination.ts
+++ b/src/logic/pathfinding/wolf/result-determination.ts
@@ -1,0 +1,27 @@
+import { Grid } from '@/types/grid';
+import { PathResult, Result } from '@/types/path';
+import { Point } from '../../utils';
+import { Candidate } from '../types';
+
+/**
+ * オオカミ用の結果判定
+ * オオカミがゴールに到達した場合は既存のResult値を使用（失敗判定は上位で処理）
+ */
+export const determineWolfResult = (
+  best: Candidate,
+  grid: Grid,
+  wolfPosition: Point
+): PathResult => {
+  // オオカミが本物ゴールに到達した場合
+  if (best.kind === 0) {
+    return { result: Result.HasClearPath, path: best.path, nextGrid: null };
+  }
+  
+  // ダミーゴールに到達した場合
+  if (best.kind === 1) {
+    return { result: Result.HasFailPath, path: best.path, nextGrid: null };
+  }
+  
+  // その他の場合（通常は発生しない）
+  return { result: Result.NoPath, path: [], nextGrid: null };
+};

--- a/src/types/path/schema.ts
+++ b/src/types/path/schema.ts
@@ -8,6 +8,7 @@ export enum Result {
   HasFailPath = "HasFailPath",
   HasRestPath = "HasRestPath",
   HasFlagPath = "HasFlagPath",
+  WolfReachedGoal = "WolfReachedGoal",
 }
 
 export const resultMessages: Record<Result, string> = {
@@ -18,6 +19,7 @@ export const resultMessages: Record<Result, string> = {
   [Result.HasFailPath]: "間違った道でした...😢",
   [Result.HasRestPath]: "休憩地点に着きました！",
   [Result.HasFlagPath]: "旗に到達しました！（続けて再生をおしてね！）",
+  [Result.WolfReachedGoal]: "オオカミがゴールに到達しました...",
 };
 
 export type Vector = {


### PR DESCRIPTION
## issue
- #86

Close #86

## 作業内容
- オオカミに対応


https://github.com/user-attachments/assets/6afcb471-cc61-4a20-8bd6-9bc57262ca14


### オオカミの仕様
- Startとおなじくゴールへ移動
- Wolfが一匹でもゴールへ到達したら失敗
- 全てのWolfの道を塞ぐ（NpPath）あるいはダミーゴール到達、そしてStartがゴールすればクリア


### 実装方法
- Wolf版のFindPath関数を作成
- 全てのWolfと1つのStartすべてのPathを出す
- 上記に描いている判定を実施し、WolfすべてClearしていない場合、StartのResultを採用

## 動作確認方法
- Wolfステージにて確認

## 今後の課題
-
