### PR TITLE
136 solver実行時にローディングとエラー出力がわかるようにする

### DIFF
--- a/src/components/solver-page.tsx
+++ b/src/components/solver-page.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 
 import { useSelector, useDispatch } from "react-redux";
-import { RootState } from "@/store";
+import { RootState, AppDispatch } from "@/store";
 import { solutionActions, solvePuzzleAsync } from "@/store/slices/solution-slice";
 import { SolverPanelList } from '@/components/solver/solver-panel-list';
 
@@ -13,13 +13,13 @@ import { SolverGridViewer } from "@/components/solver/solver-grid-viewer";
 import { useState } from "react";
 
 const SolverPage: React.FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
   const [minimizePanels, setMinimizePanels] = useState(true);
 
   const grid      = useSelector((s: RootState) => s.grid.grid);
   const panels    = useSelector((s: RootState) => s.panelList.panels);
   const solutions = useSelector((s: RootState) => s.solution.solutions);
-  const isLoading = useSelector((s: RootState) => s.solution.isLoading);
+  const status    = useSelector((s: RootState) => s.solution.status);
   const error     = useSelector((s: RootState) => s.solution.error);
 
   const solve = async () => {
@@ -52,17 +52,20 @@ const SolverPage: React.FC = () => {
         </CardHeader>
         <CardContent>
           <div className="flex flex-col gap-4">
-            {error && (
-              <div className="text-red-500 text-center">{error}</div>
+            {status === 'error' && (
+              <div className="text-red-500 text-center">
+                <div className="mb-2">{error}</div>
+                <div className="text-sm">よろしければ開発者にお伝えください</div>
+              </div>
             )}
             <div className="flex justify-center">
               <Button 
                 variant="secondary" 
                 className="w-1/4" 
                 onClick={solve}
-                disabled={isLoading}
+                disabled={status === 'loading'}
               >
-                {isLoading ? "解を探索中..." : "Solve"}
+                {status === 'loading' ? "解を探索中..." : "Solve"}
               </Button>
             </div>
             
@@ -73,18 +76,37 @@ const SolverPage: React.FC = () => {
             </div>
           </div>
 
-          <div className="flex flex-col gap-8">
-            {solutions.map((phasedSolution, solutionIdx) =>
-              phasedSolution.phases.map((_, phaseIdx) => {
-                const globalIndex = solutions.slice(0, solutionIdx).reduce((acc, ps) => acc + ps.phases.length, 0) + phaseIdx;
-                return (
-                  <div key={`${solutionIdx}-${phaseIdx}`} className="flex gap-6 items-start mr-8">
-                    <div className="text-sm mb-2">解{solutionIdx + 1} - フェーズ{phaseIdx + 1}</div>
-                    <SolverGridViewer baseGrid={grid} index={globalIndex} />
-                    <SolverPanelList solutionIndex={globalIndex} />
+          <div className="flex flex-col gap-8 mt-6">
+            {status === 'success' && (
+              <>
+                {solutions.length === 0 ? (
+                  <div className="text-center py-8">
+                    <div className="text-gray-600 text-lg mb-2">解が見つかりませんでした</div>
+                    <div className="text-sm text-gray-500">
+                      パネルの配置や条件を見直してみてください
+                    </div>
                   </div>
-                );
-              })
+                ) : (
+                  <>
+                    <div className="text-center text-sm text-gray-600 mb-4">
+                      {solutions.length}個の解が見つかりました
+                    </div>
+                    
+                    {solutions.map((phasedSolution, solutionIdx) =>
+                      phasedSolution.phases.map((_, phaseIdx) => {
+                        const globalIndex = solutions.slice(0, solutionIdx).reduce((acc, ps) => acc + ps.phases.length, 0) + phaseIdx;
+                        return (
+                          <div key={`${solutionIdx}-${phaseIdx}`} className="flex gap-6 items-start mr-8">
+                            <div className="text-sm mb-2">解{solutionIdx + 1} - フェーズ{phaseIdx + 1}</div>
+                            <SolverGridViewer baseGrid={grid} index={globalIndex} />
+                            <SolverPanelList solutionIndex={globalIndex} />
+                          </div>
+                        );
+                      })
+                    )}
+                  </>
+                )}
+              </>
             )}
           </div>
 

--- a/src/store/slices/solution-slice.ts
+++ b/src/store/slices/solution-slice.ts
@@ -19,17 +19,19 @@ export const solvePuzzleAsync = createAsyncThunk(
   }
 );
 
+type SolverStatus = 'not_executed' | 'loading' | 'success' | 'error';
+
 type SolutionState = {
   solutions: PhasedSolution[];
   numberGrids: NumberGrid[];
-  isLoading: boolean;
+  status: SolverStatus;
   error: string | null;
 };
 
 const initialState: SolutionState = {
   solutions: [],
   numberGrids: [],
-  isLoading: false,
+  status: 'not_executed',
   error: null,
 };
 
@@ -83,15 +85,15 @@ const solutionSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(solvePuzzleAsync.pending, (state) => {
-        state.isLoading = true;
+        state.status = 'loading';
         state.error = null;
       })
       .addCase(solvePuzzleAsync.fulfilled, (state, action) => {
-        state.isLoading = false;
+        state.status = 'success';
         state.solutions = action.payload;
       })
       .addCase(solvePuzzleAsync.rejected, (state, action) => {
-        state.isLoading = false;
+        state.status = 'error';
         state.error = action.error.message || '解の探索に失敗しました';
       });
   },

--- a/src/store/slices/solution-slice.ts
+++ b/src/store/slices/solution-slice.ts
@@ -1,15 +1,36 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
 import { PanelPlacement, PhasedSolution } from "@/types/panel-placement";
 import { NumberGrid } from "@/types/solution";
+import { Grid } from "@/types/grid";
+import { Panel } from "@/types/panel";
+import { solvePuzzle } from "@/logic";
+
+export const solvePuzzleAsync = createAsyncThunk(
+  'solution/solve',
+  async ({ grid, panels, minimizePanels }: { 
+    grid: Grid, 
+    panels: Panel[], 
+    minimizePanels: boolean 
+  }) => {
+    // UIの更新を可能にするため、少し待機
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const response = solvePuzzle(grid, panels, minimizePanels);
+    return response.solutions;
+  }
+);
 
 type SolutionState = {
   solutions: PhasedSolution[];
-  numberGrids: NumberGrid[]; 
+  numberGrids: NumberGrid[];
+  isLoading: boolean;
+  error: string | null;
 };
 
 const initialState: SolutionState = {
   solutions: [],
   numberGrids: [],
+  isLoading: false,
+  error: null,
 };
 
 const buildNumberGrid = (
@@ -54,6 +75,25 @@ const solutionSlice = createSlice({
       state.solutions = [];
       state.numberGrids = [];
     },
+
+    clearError(state) {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(solvePuzzleAsync.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(solvePuzzleAsync.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.solutions = action.payload;
+      })
+      .addCase(solvePuzzleAsync.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || '解の探索に失敗しました';
+      });
   },
 });
 


### PR DESCRIPTION
## issue
- #136

Close #136

## 作業内容
- 「未実行/実行中/エラー/成功（解ありなし）」の5状態での表示を実装
-  詳しくは以下に記載
   - https://github.com/Suke-H/kiro_stage_editor/issues/136#issuecomment-3245845897
- これにより「実行中/エラー/解なし」の区別がつくようにした 

## 動作確認方法
- 上記#136にて確認

## 今後の課題
-
