### PR TITLE
#138 Cut-Pasteのアンドゥの挙動を修正

### DIFF
--- a/src/components/editor/grid-viewer.tsx
+++ b/src/components/editor/grid-viewer.tsx
@@ -24,7 +24,7 @@ export const GridViewer: React.FC = () => {
   const gridHistory     = useSelector((s: RootState) => s.grid.gridHistory);
   const selectedCellKey = useSelector((s: RootState) => s.cellType.selectedCellType) as GridCellKey;
   const placementMode   = useSelector((s: RootState) => s.panelPlacement.panelPlacementMode);
-  const copyPanels      = useSelector((s: RootState) => s.copyPanelList.panels);
+  const copyPanels      = useSelector((s: RootState) => s.copyPanelList.copyPanels);
 
   const handleGridCellClick = (rowIdx: number, colIdx: number): void => {
     const placing = placementMode.panel;           // Panel | CopyPanel | null

--- a/src/components/editor/panel-list.tsx
+++ b/src/components/editor/panel-list.tsx
@@ -43,7 +43,7 @@ export const PanelList: React.FC = () => {
   const dispatch = useDispatch();
   const studioMode = useSelector((s: RootState) => s.studioMode.studioMode);
   const panels     = useSelector((s: RootState) => s.panelList.panels);
-  const copyPanels = useSelector((s: RootState) => s.copyPanelList.panels);
+  const copyPanels = useSelector((s: RootState) => s.copyPanelList.copyPanels);
   const placement  = useSelector((s: RootState) => s.panelPlacement.panelPlacementMode);
 
   /* -------- パネル選択 -------- */

--- a/src/components/editor/panel-list/placement-controll-part.tsx
+++ b/src/components/editor/panel-list/placement-controll-part.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { panelPlacementSlice } from "@/store/slices/panel-placement-slice";
 import { panelListSlice } from "@/store/slices/panel-list-slice";
+import { copyPanelListSlice } from "@/store/slices/copy-panel-list-slice";
 import { gridSlice } from "@/store/slices/grid-slice";
 import { studioModeInEditorSlice } from "@/store/slices/studio-mode-in-editor-slice";
 import { RootState } from "@/store";
@@ -19,6 +20,7 @@ export const PlacementControllPart: React.FC = () => {
   const gridHistory = useSelector((state: RootState) => state.grid.gridHistory);
   const phaseHistory = useSelector((state: RootState) => state.grid.phaseHistory);
   const grid = useSelector((state: RootState) => state.grid.grid);
+  const lastOperationType = useSelector((state: RootState) => state.copyPanelList.lastOperationType);
   
   // クリア状態を管理するローカルstate
   const [isCleared, setIsCleared] = useState<boolean>(false);
@@ -27,8 +29,21 @@ export const PlacementControllPart: React.FC = () => {
   
   // 「1つ戻す」メソッド
   const undoLastPlacement = () => {
-    dispatch(panelListSlice.actions.undo());
-    dispatch(gridSlice.actions.undo());
+    if (lastOperationType === 'cut' || lastOperationType === 'paste') {
+      // Cut/Paste操作の場合
+      dispatch(copyPanelListSlice.actions.undo());
+      dispatch(panelListSlice.actions.undo());
+      dispatch(gridSlice.actions.undo());
+
+      if (lastOperationType === 'paste') {
+        dispatch(gridSlice.actions.undo()); // Paste後は2回グリッドアンドゥ
+      }
+    } else {
+      // 通常パネルの場合
+      dispatch(panelListSlice.actions.undo());
+      dispatch(gridSlice.actions.undo());
+    }
+
     setIsCleared(false);
   };
 

--- a/src/types/store/states.ts
+++ b/src/types/store/states.ts
@@ -21,8 +21,9 @@ export interface PanelListState {
 }
 
 export interface CopyPanelListState {
-  panels: CopyPanel[];
-  removedPanels: { panel: CopyPanel; index: number }[];
+  copyPanels: CopyPanel[];
+  pastedPanels: CopyPanel[];
+  lastOperationType: 'cut' | 'paste' | null;
 }
 
 export interface CreatePanelState {


### PR DESCRIPTION
## issue
- #138 
- #139 

Closes #138, #139

## 作業内容
- カットしてコピーパネル作成後、アンドゥするとコピーパネルが残り続ける問題があったので修正
- ペースト後のアンドゥは、カット以前の状態に戻すようにした
  - ボード状態に対してカットパネルのアンドゥ が進んでしまう問題（#139）があったので、それも同時に解消できた

## 動作確認方法
- 以下ステージで挙動確認
  - http://localhost:5074/stage?cells=h4w4gwwwgeeeewwwwswww&panels=h2w2gbbbb_c-h1w2gbb&mode=play
- カット後のアンドゥ、カットペースト後のアンドゥ、反転を挟んでも問題ないか 

## 今後の課題
-
